### PR TITLE
Remove advagg in installation profile

### DIFF
--- a/social.profile
+++ b/social.profile
@@ -345,7 +345,6 @@ function social_theme_setup(array &$install_state) {
     'rest',
     'waterwheel',
     'simple_oauth',
-    'advagg',
     'votingapi',
     'openid_connect',
     'big_pipe'


### PR DESCRIPTION
Need to remove this line as we will be getting an error when compiling. This was added to enable advagg module and needed to be removed.